### PR TITLE
feat(ci): add InfraScan Audit workflow

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,33 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.5
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14

--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -17,7 +17,7 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
## Description
This PR introduces the **InfraScan Audit GitHub Actions workflow** (`.github/workflows/infrascan.yml`) to automate infrastructure auditing for every push and pull request. 

The motivation for adding this automated scan comes from an [initial audit](https://infrascan.soldevelo.com/?scan_id=f524e279-255d-4c4d-ade6-446008117963) performed via the InfraScan tool on infrastructure, which identified specific areas for improvement:

* **Overall Grade:** B (91.6%)
* **Findings:** While **Cost Optimization** and **Container Security** scored an A (100% - 0 violations), the scan revealed **171 medium-severity IaC Security findings** across 46 unique rules. Frequent issues include missing geo-redundant backups for PostgreSQL, missing `content_type` on Key Vault secrets, and public access configurations on Storage Accounts.

By integrating this workflow, we ensure that every code change is automatically audited for infrastructure security risks. The generated HTML reports are uploaded as artifacts (retained for 14 days) to help us systematically address these findings and move toward a perfect grade.

## Related Issue(s)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) - *Verified workflow syntax and tested action execution.*
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out) - *The CI workflow itself acts as our automated infrastructure test.*
- [x] All tests run green

---
**Notes:**
* **Artifacts:** The workflow uses `if: always()` to ensure diagnostic artifacts (`report.html`) are provided even if the scan identifies failures.
* **Scanner:** Uses `soldevelo/infrascan@v1.0.5` configured with the `comprehensive` scanner setting and HTML format output.